### PR TITLE
Dependency style consistency 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage-core", from: "0.1.1"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage-core.git", from: "0.1.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Contributed fix last night was missing the .git, suffix. Without it it also works but it’s not consistent.